### PR TITLE
2206/이재용

### DIFF
--- a/BFS/BJ_2206/이재용.java
+++ b/BFS/BJ_2206/이재용.java
@@ -1,0 +1,50 @@
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Main {
+	public static void main(String[] args) throws Exception {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st = new StringTokenizer(br.readLine(), " ");
+		int N = Integer.parseInt(st.nextToken());
+		int M = Integer.parseInt(st.nextToken());
+		int[][] map = new int[N][M];
+		for (int i = 0; i < N; i++) {
+			String str = br.readLine();
+			for (int j = 0; j < M; j++) {
+				map[i][j] = str.charAt(j) - '0';
+			}
+		}
+		Queue<int[]> queue = new ArrayDeque<>();
+		int[][] directions = { { -1, 0 }, { 1, 0 }, { 0, -1 }, { 0, 1 } };
+		boolean[][][] visited = new boolean[2][N][M];
+		queue.offer(new int[] { 0, 0, 1, 0 }); // row, col, count, wall
+		int ans = Integer.MAX_VALUE;
+		while (!queue.isEmpty()) {
+			int[] current = queue.poll();
+			int cr = current[0];
+			int cc = current[1];
+			int cnt = current[2];
+			int wl = current[3];
+			if (cr == N - 1 && cc == M - 1) {
+				System.out.println(cnt);
+				return;
+			}
+			for (int[] dir : directions) {
+				int nr = cr + dir[0];
+				int nc = cc + dir[1];
+				if (0 <= nr && nr < N && 0 <= nc && nc < M && !visited[wl][nr][nc] && map[nr][nc] == 0) {
+					visited[wl][nr][nc] = true;
+					queue.offer(new int[] { nr, nc, cnt + 1, wl });
+				}
+				if (0 <= nr && nr < N && 0 <= nc && nc < M && wl == 0 && !visited[1][nr][nc] && map[nr][nc] == 1) {
+					visited[1][nr][nc] = true;
+					queue.offer(new int[] { nr, nc, cnt + 1, 1 });
+				}
+			}
+		}
+		System.out.println(-1);
+	}
+}


### PR DESCRIPTION
### \*\*\*\*

시간:600ms
메모리:87532KB
회고:
BFS의 특징에 대한 이해가 부족해서 처음에 불필요하게 어렵게 풀었습니다. 
BFS는 결국 모든 가능한 상태(좌표 + 조건)를 전부 탐색하지만, 중복된 상태는 방문 배열로 걸러내면서 최단경로만 남깁니다. 

배열 탐색 문제라면 목표 지점에 가장 먼저 도착하는 순간이 곧 최단거리이기 때문에, 도착 즉시 탐색을 종료해도 됩니다.
같은 지점이라도 벽을 부수고 온 경우와 부수지 않고 온 경우를 서로 다른 상태로 관리하기만 하면 되는 것이었씁니다.

처음에는 어떤 경로가 더 짧은지 min 비교를 따로 했지만, BFS에서는 그런 비교 없이 도착 즉시 반환하면 됩니다.
결국 핵심은 현재 좌표, 벽을 부쉈는지 여부만 정확히 관리하면서 다음 갈 수 있는 경우만 큐에 넣으면 된다는 것이었습니다...

<!-- - 코드 리뷰에서 피드백 받고 싶은 포인트가 있다면 추가로 작성해주세요
  예)
  시간:93ms
  메모리: 1235548kb
  회고: 이번 알고리즘은 이해하는데에 시간이 걸렸습니다. 하지만 구현을 시작한 이후에는 생각보다 잘 풀렸습니다.
  -->
