### PR TITLE
2003/유동훈

### DIFF
--- a/Two_Pointers/BJ_2003/유동훈.java
+++ b/Two_Pointers/BJ_2003/유동훈.java
@@ -1,0 +1,43 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_2003 {
+
+	public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        int[] arr = new int[N];
+        st = new StringTokenizer(br.readLine());
+
+        for (int i = 0; i < N; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int left = 0, right = 0, sum = 0, cnt = 0;
+        
+        // 2249번 문제랑 다른 점은, 구하고자 하는 슬라이딩 윈도우의 크기가 정해져있냐 그렇지 않냐로 나뉨. for로 접근하면 풀 수 없는 것 같음.
+        while (true) {
+            if (sum >= M) {
+                sum -= arr[left]; // 로직은 같지만, 투 포인터를 운용해야 함. sum이 기준보다 작으면 right++ 크면 left++ 이것만 기억하면 됨.
+                left++;
+            } else if (right == N) {
+                break;
+            } else {
+                sum += arr[right];
+                right++;
+            }
+
+            if (sum == M) {
+            	cnt++;
+            }
+        }
+
+        System.out.println(cnt);
+	}
+}


### PR DESCRIPTION
### \*\*\*\*

시간: 128ms
메모리: 15056KB
회고: 투포인터 문제는 당연히 첫 인덱스와 끝 인덱스부터 시작해서 중간에 만나는 느낌인 줄 알았는데, 문제의 유형에 따라 투포인터냐 슬라이딩 윈도우냐 구분된다는 걸 느꼈습니다.
2249번 문제랑 다른 점은, 구하고자 하는 슬라이딩 윈도우의 크기가 정해져있냐 그렇지 않냐로 나뉘기 때문에, for로 접근하면 풀 수 없는 것 같다고 생각했습니다. 
해당 문제의 경우 특정 idx부터 특정 idx까지 고정된 크기가 아니기 때문에 left, right를 이용해서 투포인터 로직을 운용했습니다.