### PR TITLE
3273/유동훈

### DIFF
--- a/Two_Pointers/BJ_3273/유동훈.java
+++ b/Two_Pointers/BJ_3273/유동훈.java
@@ -1,0 +1,40 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+
+public class BOJ_3273 {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		
+		int n = Integer.parseInt(br.readLine());
+		int[] arr = new int[n];
+		
+		
+		StringTokenizer st = new StringTokenizer(br.readLine());
+		for (int i = 0; i < n; i++) {
+			arr[i] = Integer.parseInt(st.nextToken());
+		}
+		Arrays.sort(arr);
+		
+		st = new StringTokenizer(br.readLine());
+		int x = Integer.parseInt(st.nextToken());
+
+		int left = 0, right = n - 1, sum = 0, cnt = 0;
+		
+		while (left < right) {
+			sum = arr[left] + arr[right];
+			if (sum < x) {
+				left++;
+			} else if (sum == x) {
+				cnt++;
+				left++;
+			} else {
+				right--;
+			}
+		}
+		
+		System.out.println(cnt);
+	}
+}


### PR DESCRIPTION
### \*\*\*\*

시간: 364ms
메모리: 26520KB
회고: 기본적으로 생각했던 건, 배열에 **중복**이 없다면, **정렬**을 시켜서 양 끝단에 left, right 변수를 움직여주면서 합을 확인해보면 된다고 생각했습니다. 왜냐하면 정렬이 되어있기 때문에 left는 제일 작은 값, right는 제일 큰 값부터 시작해서 left는 값이 점점 증가하고, right는 값이 제일 감소하는 방향성을 보이게 됩니다. 따라서 두 수의 합이 찾고자 하는 sum보다 작다면, left를 증가시켜서 sum을 늘려보며 확인하고 만약 sum보다 크다면, right를 감소시켜서 sum을 줄여주며 확인해보면 됩니다.

그리고
```java
	} else if (sum == x) {
		cnt++;
		left++;
                right--;
```
이 부분에 대한 생각을 좀 많이 해봤는데, 주의할 필요가 있는 코드라고 생각했습니다.
일단 sum이 x와 같아졌을 때, left만 증가시켜준다고 했을 때 생길 수 있는 문제가 무엇이냐면
{1 2 2 3 4 5} -> left: 2   right: 4  -> sum: 6
{1 2 2 3 4 5} -> left: 2(left++)   right: 4  -> sum: 6
이렇게 두 수의 합이 중복될 수 있다는 겁니다.
하지만 이 문제의 전제 조건은 배열에 중복 요소 및 정렬이 되어있어야 한다는 것이긴 합니다.

아무튼 문제마다 주어진 조건에 따라서 이게 정답이 될 수도 안될 수도 있는데 left, right를 어떻게 움직이느냐가 생각보다 값에 중요한 영향을 미치기 때문에 잘 확인해야 할 것 같습니다.

아 그래서 저는 left는 증가, right는 감소 시켰는데 그 이유는, 해당 문제가 배열에 중복이 없고 정렬이 되어있기 때문에 두 포인터를 이동시켜도 문제가 없다는 걸 도출했기 때문입니다!

sum이랑 x랑 동일할 때, left나 right만 한 번 움직였다면 다음 포인터의 이동을 한다해도 절대 다시 sum과 x가 같아질 수 없기 때문에 1번의 while문의 반복이 추가됩니다.

그렇기 때문에 한 번에 두 개의 포인터를 이동시켜서 while문 연산을 줄여보고자 했습니다.

긴 글 읽어주셔서 감사합니당 👍 