### PR TITLE
Create 유동훈.java

### DIFF
--- a/Two_Pointers/BJ_10025/유동훈.java
+++ b/Two_Pointers/BJ_10025/유동훈.java
@@ -1,0 +1,55 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class BOJ_10025 {
+
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringTokenizer st;
+		
+		st = new StringTokenizer(br.readLine());
+		
+		int N = Integer.parseInt(st.nextToken());
+		int K = Integer.parseInt(st.nextToken());
+		
+		
+		int[] arr = new int[3000001];
+//		int[] arr = new int[1000001];
+		// 배열 인덱스 관련한 런타임 에러 계속 났음
+		// 백곰이 만약, 1,000,000에 위치해 있고, 백곰의 이동 반경인 K가 2,000,000 일 경우가 존재하기 때문인듯
+		// 응 여전히 런타임 에러야
+		
+		
+		int maxIdx = 0;
+		
+		for (int i = 0; i < N; i++) {
+			st = new StringTokenizer(br.readLine());
+			int ice = Integer.parseInt(st.nextToken());
+			int idx = Integer.parseInt(st.nextToken());
+			maxIdx = Math.max(maxIdx, idx);
+			arr[idx] = ice;
+		}
+		
+		int maxSum = 0;
+		int sum = 0;
+		
+		// 백곰이 x에 위치한다고 하면, [x - K, x + K]의 구간을 탐색할 수 있음. -> 2K + 1
+		// 최초의 2K + 1 만큼의 합을 구한 뒤, 슬라이딩 윈도우를 진행시키면 됨.
+		int searchLen = (K * 2) + 1;
+		for (int i = 0; i < searchLen; i++) {
+			if (i >= arr.length) break; // maxIdx는 사실 백곰의 탐색 범위 안의 값이기 때문에 K가 최대값인 1,000,000인 경우, 2,000,001인데 maxIdx가 가질 수 있는 값은 0 ~ 1,000,000 임. 그 상황 방지.
+			sum += arr[i];
+		}
+		maxSum = Math.max(maxSum, sum);
+		
+		for (int i = searchLen; i <= maxIdx; i++) { // maxIdx는 실제 인덱스니까 포함 시켜야 함.
+			if (i >= arr.length) break; // maxIdx는 사실 백곰의 탐색 범위 안의 값이기 때문에 K가 최대값인 1,000,000인 경우, 2,000,001인데 maxIdx가 가질 수 있는 값은 0 ~ 1,000,000 임. 그 상황 방지.
+			sum += arr[i] - arr[i - searchLen];
+            maxSum = Math.max(maxSum, sum);
+		}
+		
+		System.out.println(maxSum);
+	}
+}


### PR DESCRIPTION
### \*\*\*\*

시간: 340mx
메모리: 49136KB
회고: 일단 많은 문제를 겪었습니다. 투포인터 관련 개념이 뚜렷하게 정립되어 있지 않다보니 많은 부분을 놓쳤습니다. 실제로 인덱스 값 하나로 예외가 터질 수도 있는 민감한 알고리즘인데, 제 파일의 주석을 잘 보면 열심히 고뇌한 흔적을 엿보실 수 있습니다.

우선 처음을 생각해보면, 백곰이 이동할 수 있는 범위를 잘못 생각했습니다. 백곰이 1,000,000 좌표에 위치한 상태라면, 좌우로 2,000,000 만큼 떨어진 곳까지 이동할 수 있습니다. 또한 양동이는 0부터 1,000,000까지 위치할 수 있기 때문에 백곰이 총 이동할 수 있는 범위는
0부터 1,000,000이 아니라 0부터 3,000,000이 됩니다. 일단 이 부분을 놓쳤습니다.

그리고 백곰의 탐색 구간 searchLen와 관련된 문제입니다..
백곰이 x에 위치한다고 하면, [x - K, x + K]의 구간을 탐색할 수 있습니다. -> 2K + 1
따라서 searchLen이 2K + 1이 되어야 하는데 이 값을 통해서 백곰의 이동 범위 배열을 탐색하게 되면 배열 인덱스 오류가 터질 수 있습니다. 왜냐하면, 

```java
for (int i = 0; i < searchLen; i++) {
			if (i >= arr.length) break;
// maxIdx는 사실 백곰의 탐색 범위 안의 값이기 때문에 K가 최대값인 1,000,000인 경우, 2,000,001인데 maxIdx가 가질 수 있는 값은 0 ~ 1,000,000 임. 그 상황 방지.
			sum += arr[i];
		}
```

searchLen(2K + 1)이 백곰의 이동 범위 배열의 크기인 3,000,000을 넘길 수도 있게 됩니다.
만약, 백곰의 이동 반경을 뜻하는 K가 1,500,000만 되더라도 searchLen이 3,000,001이 됩니다. 물론 K 값의 조건도 충족하니까 충분히 일어날 수 있는 상황입니다.

따라서 이걸 방지해줬습니다!